### PR TITLE
feat(backend): add SPA routing support for React frontend

### DIFF
--- a/backend/src/main/java/org/pertitrack/backend/config/SpaWebConfig.java
+++ b/backend/src/main/java/org/pertitrack/backend/config/SpaWebConfig.java
@@ -1,0 +1,21 @@
+package org.pertitrack.backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class SpaWebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addViewControllers(ViewControllerRegistry registry) {
+        // top level: e.g., /dashboard, /settings
+        registry.addViewController("/{p1:^(?!auth|api|assets)[^.]*}")
+                .setViewName("forward:/index.html");
+
+        // nested routes: remaining segments no dots
+        // e.g., /dashboard/project, /settings/users/1234567890
+        registry.addViewController("/{p1:^(?!auth|api|assets)[^.]*}/**/{path:[^.]*}")
+                .setViewName("forward:/index.html");
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -9,10 +9,15 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.show-sql=true
 spring.jpa.database=postgresql
 
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
+
 # JWT Configuration
 app.jwtSecret=${JWT_SECRET}
 # 15 minutes
 app.jwtExpirationMs=900000
+
+# cors allowed origins
+app.cors.allowed-origins=${CORS_ALLOWED_ORIGINS}
 
 # Flyway settings
 spring.flyway.enabled=false
@@ -71,15 +76,3 @@ management.endpoints.web.cors.allowed-methods=GET,POST
 # Actuator logging
 logging.level.org.springframework.boot.actuate=INFO
 logging.level.org.springframework.boot.actuate.health=DEBUG
-
-# ========================================
-# METRICS CONFIGURATION (Optional)
-# ========================================
-
-# Enable metrics
-management.metrics.enable.jvm=true
-management.metrics.enable.process=true
-management.metrics.enable.system=true
-management.metrics.enable.http=true
-
-

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
             '/api': {
                 target: 'http://localhost:8080',
                 changeOrigin: true,
+                secure: false,
             }
         }
     },


### PR DESCRIPTION
- Create SpaWebConfig to handle client-side routing with forward to index.html
- Update WebSecurityConfig to permit all SPA routes (excluding /auth, /api, /assets)
- Add Ant path matcher strategy for enhanced pattern matching
- Support nested SPA routes (e.g., /dashboard/project, /settings/users/123)